### PR TITLE
Expanded attachment parsing comment

### DIFF
--- a/Matterfeed.NET/RedditJsonFeedReader.cs
+++ b/Matterfeed.NET/RedditJsonFeedReader.cs
@@ -87,7 +87,7 @@ namespace Matterfeed.NET
                                             TitleLink = item.Data.Context != "" ?  new Uri($"https://reddit.com{item.Data.Context}") : null,
                                             Text =
                                                 item.Data.Body.Replace("](/r/",
-                                                    "](https://reddit.com/r/"), //expand /r/ markdown links
+                                                    "](https://reddit.com/r/"), //expand /r/ markdown links, does not correctly parse promoted links
                                             Pretext = feed.FeedPretext
                                         }
                                     };


### PR DESCRIPTION
Expand attachment parsing comment to reflect this section of code cannot create an appropriate attachment out of a Promoted post's URL. 

Promoted links on Reddit do not appear to have a r/subreddit in their URL, example: https://www.reddit.com/comments/75a19z/solid_remote_support_that_wont_cost_you_a_dime/