### PR TITLE
Use HTTPS for AuthorIcon

### DIFF
--- a/Matterfeed.NET/TwitterFeedReader.cs
+++ b/Matterfeed.NET/TwitterFeedReader.cs
@@ -69,7 +69,7 @@ namespace Matterfeed.NET
                                                     AuthorName = t.CreatedBy.Name ?? "",
                                                     AuthorLink =
                                                         new Uri($"https://twitter.com/{t.CreatedBy.ScreenName}"),
-                                                    AuthorIcon = new Uri(t.CreatedBy.ProfileImageUrl400x400 ?? "")
+                                                    AuthorIcon = new Uri(t.CreatedBy.ProfileImageUrlHttps400x400 ?? "")
                                                 }
                                             }
                                         };


### PR DESCRIPTION
Use HTTPS URI for AuthorIcon on TwitterFeedReader.